### PR TITLE
Setup firestore for boards

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,10 +39,13 @@ apply plugin: 'com.google.gms.google-services'  // Added for Firebase Database
 dependencies {
 
     // Import the Firebase BoM
-    implementation platform('com.google.firebase:firebase-bom:26.7.0') // Added for Firebase Database
+    implementation platform('com.google.firebase:firebase-bom:27.0.0')
     // Add the dependency for the Firebase SDK for Google Analytics
     // When using the BoM, don't specify versions in Firebase dependencies
-    implementation 'com.google.firebase:firebase-analytics-ktx'  // Added for Firebase Database
+    // declare the dependencies for Firebase Authentication and Cloud Firestore
+    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.google.firebase:firebase-firestore-ktx'
+    implementation 'com.google.firebase:firebase-auth-ktx'
 
     // Add the dependencies for any other desired Firebase products
     // https://firebase.google.com/docs/android/setup#available-libraries
@@ -59,11 +62,4 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-
-    // Import the BoM for the Firebase platform
-    implementation platform('com.google.firebase:firebase-bom:26.8.0')
-
-    // Declare the dependency for the Firebase Authentication library
-    // When using the BoM, you don't specify versions in Firebase library dependencies
-    implementation 'com.google.firebase:firebase-auth-ktx'
 }

--- a/app/src/main/java/com/example/fuji/BoardFragment.kt
+++ b/app/src/main/java/com/example/fuji/BoardFragment.kt
@@ -10,7 +10,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.fuji.models.Board
 import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.firestore.ktx.toObject
 import com.google.firebase.ktx.Firebase
 
 class BoardFragment : Fragment() {
@@ -32,11 +31,12 @@ class BoardFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val boardListView = view.findViewById<RecyclerView>(R.id.board_list)
 
-        db.collection("boards").get().addOnSuccessListener { result ->
+        db.collection("/boards").get().addOnSuccessListener { result ->
             val boards = arrayListOf<Board>()
 
             for (document in result) {
-                boards.add(document.toObject<Board>())
+                val title = document["Title"].toString()
+                boards.add(Board(Title = title))
             }
 
             boardListView.apply {

--- a/app/src/main/java/com/example/fuji/BoardFragment.kt
+++ b/app/src/main/java/com/example/fuji/BoardFragment.kt
@@ -1,24 +1,23 @@
 package com.example.fuji
 
-import android.app.Activity
-import android.content.Intent
-import android.icu.text.CaseMap
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.TextView
-import androidx.navigation.fragment.findNavController
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.fuji.models.Board
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.firestore.ktx.toObject
+import com.google.firebase.ktx.Firebase
 
 class BoardFragment : Fragment() {
 
     private var layoutManager: RecyclerView.LayoutManager? = null
     private var adapter: RecyclerView.Adapter<BoardAdapter.ViewHolder>? = null
+    private val db = Firebase.firestore
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,20 +30,25 @@ class BoardFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val boardlist = view.findViewById<RecyclerView>(R.id.board_list)
-        val temp = arrayListOf<Board>()
-        val temp2 = Board("testing")
-        val temp3 = Board("another test")
-        temp.add(temp2)
-        temp.add(temp3)
-        boardlist.apply {
-            layoutManager = LinearLayoutManager(activity)
-            adapter = BoardAdapter(temp)
+        val boardListView = view.findViewById<RecyclerView>(R.id.board_list)
+
+        db.collection("boards").get().addOnSuccessListener { result ->
+            val boards = arrayListOf<Board>()
+
+            for (document in result) {
+                boards.add(document.toObject<Board>())
+            }
+
+            boardListView.apply {
+                layoutManager = LinearLayoutManager(activity)
+                adapter = BoardAdapter(boards)
+            }
         }
 
 
+
         view.findViewById<ImageView>(R.id.add_board_icon).setOnClickListener {
-            var createBoard: BoardsActivity = activity as BoardsActivity
+            val createBoard: BoardsActivity = activity as BoardsActivity
                 createBoard.switchToCreateBoardFragment()
         }
     }

--- a/app/src/main/java/com/example/fuji/LoginFragment.kt
+++ b/app/src/main/java/com/example/fuji/LoginFragment.kt
@@ -3,11 +3,11 @@ package com.example.fuji
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
@@ -37,22 +37,24 @@ class LoginFragment : Fragment() {
         // Initialize Firebase Auth
         auth = Firebase.auth
 
-        val emailInput = view.findViewById<EditText>(R.id.login_email_entry).text
-        val passwordInput = view.findViewById<EditText>(R.id.login_password_entry).text
+        val emailInputView = view.findViewById<EditText>(R.id.login_email_entry)
+        val passwordInputView = view.findViewById<EditText>(R.id.login_password_entry)
 
         view.findViewById<TextView>(R.id.register_text).setOnClickListener {
             findNavController().navigate(R.id.action_LoginFragment_to_RegisterFragment)
         }
 
         view.findViewById<Button>(R.id.login_button).setOnClickListener {
+            val emailInput = emailInputView.text.toString().trim()
+            val passwordInput = passwordInputView.text.toString().trim()
 
-            if (emailInput.toString().trim().isEmpty() ||
-                passwordInput.toString().trim().isEmpty()) {
+            if (emailInput.isEmpty() ||
+                passwordInput.isEmpty()) {
                 Toast.makeText(context, "Please fill all fields first", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
-            signIn(emailInput.toString().trim(), passwordInput.toString().trim())
+            signIn(emailInput, passwordInput)
             //val intent = Intent(view.context, BoardsActivity::class.java)
             //startActivity(intent)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -2,19 +2,13 @@
 buildscript {
     ext.kotlin_version = "1.4.30"
     repositories {
-        google() // Added for firebase database / Google's Maven respository
+        google() // Added for firebase database / Google's Maven repository
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.5' // Added for firebase database
-        // Import the BoM for the Firebase platform
-        //implementation platform('com.google.firebase:firebase-bom:26.8.0')
-
-        // Declare the dependency for the Firebase Authentication library
-        // When using the BoM, you don't specify versions in Firebase library dependencies
-        //implementation 'com.google.firebase:firebase-auth-ktx'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 12 16:13:13 CST 2021
+#Mon Apr 12 19:09:20 CDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
A couple of things in this PR

1. first setup of firestore for boards view. It will pull the collection of boards and then render them
2. fixed bug with login. On view creation, the `text` values for the login fields were captured but they never got updated.
3. cleaned up some commented code